### PR TITLE
Update deployment files for K8S v1.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,7 @@ Quobyte CSI is the implementation of
 
 ## Requirements
 
-* Kubernetes v1.14 or v1.15
-  * `ExpandCSIVolumes` feature-gate must be enabled on api-server, controller-manager and kubelet
-    to use volume expansion feature.
+* Kubernetes v1.16
 * Quobyte installation with reachable registry and api services from the Kubernetes nodes and pods
 * Quobyte client with mount path as `/mnt/quobyte/mounts`. Please see
  [Deploy Quobyte clients](docs/deploy_clients.md) for Quobyte client installation instructions.
@@ -62,6 +60,9 @@ Quobyte CSI is the implementation of
 
 4. Deploy RBAC and Kubernetes CSI helper
  containers along with Quobyte CSI plugin containers
+   
+   If your Quobyte installation uses self-signed certificates, the driver containers need some adjustments.
+   See the [issue](https://github.com/quobyte/quobyte-csi/issues/7) for more details.
 
     On Kubernetes **with PodSecurityPolicies**
 

--- a/deploy/csi-driver-PSP.yaml
+++ b/deploy/csi-driver-PSP.yaml
@@ -33,11 +33,14 @@ spec:
   podInfoOnMount: false
 ---
 kind: StatefulSet
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 metadata:
   name: quobyte-csi-controller
   namespace: kube-system
 spec:
+  selector:
+    matchLabels:
+      app: quobyte-csi-controller
   serviceName: "quobyte-csi"
   replicas: 1
   template:
@@ -351,7 +354,7 @@ roleRef:
 ---
 
 kind: DaemonSet
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 metadata:
   name: quobyte-csi-node
   namespace: kube-system

--- a/deploy/csi-driver.yaml
+++ b/deploy/csi-driver.yaml
@@ -7,11 +7,14 @@ spec:
   podInfoOnMount: false
 ---  
 kind: StatefulSet
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 metadata:
   name: quobyte-csi-controller
   namespace: kube-system
 spec:
+  selector:
+    matchLabels:
+      app: quobyte-csi-controller
   serviceName: "quobyte-csi"
   replicas: 1
   template:
@@ -310,7 +313,7 @@ roleRef:
 ---
 
 kind: DaemonSet
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 metadata:
   name: quobyte-csi-node
   namespace: kube-system


### PR DESCRIPTION
K8S v1.16 has few changes to the resources that require update to the deployment files.
* Expand CSI volume is promoted to Beta i.e; feature gate is enabled by default.
* Removed support for some of the old resource definition i.e; requires resource file updates