### PR TITLE
Fix orphaned pod log flooding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:18.04
 
+RUN apt-get -y update && apt-get install -y attr
+
 ADD quobyte-csi /bin
 
 ENTRYPOINT ["/bin/quobyte-csi"]

--- a/README.md
+++ b/README.md
@@ -39,14 +39,14 @@ Quobyte CSI is the implementation of
     ```bash
     git clone https://github.com/quobyte/quobyte-csi.git
     cd quobyte-csi
-    git checkout tags/v1.0.3 # checkout release v1.0.3
+    git checkout tags/v1.0.4 # checkout release v1.0.4
     ```
     Using `SSH`
 
     ```bash
     git clone git@github.com:quobyte/quobyte-csi.git
     cd quobyte-csi
-    git checkout tags/v1.0.3 # checkout release v1.0.3
+    git checkout tags/v1.0.4 # checkout release v1.0.4
     ```
 
 2. Edit [deploy/config.yaml](deploy/config.yaml) and configure `quobyte.apiURL` with your Quobyte cluster API URL.

--- a/deploy/csi-driver-PSP.yaml
+++ b/deploy/csi-driver-PSP.yaml
@@ -102,7 +102,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: quobyte-csi-plugin
-          image: quay.io/quobyte/csi:v1.0.2
+          image: quay.io/quobyte/csi:v1.0.4
           imagePullPolicy: "Always"
           args :
             - "--csi_socket=$(CSI_ENDPOINT)"
@@ -402,7 +402,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: quay.io/quobyte/csi:v1.0.2
+          image: quay.io/quobyte/csi:v1.0.4
           imagePullPolicy: "Always"
           args :
             - "--csi_socket=$(CSI_ENDPOINT)"

--- a/deploy/csi-driver.yaml
+++ b/deploy/csi-driver.yaml
@@ -77,7 +77,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: quobyte-csi-plugin
-          image: quay.io/quobyte/csi:v1.0.2
+          image: quay.io/quobyte/csi:v1.0.4
           imagePullPolicy: "Always"
           args :
             - "--csi_socket=$(CSI_ENDPOINT)"
@@ -362,7 +362,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: quay.io/quobyte/csi:v1.0.2
+          image: quay.io/quobyte/csi:v1.0.4
           imagePullPolicy: "Always"
           args :
             - "--csi_socket=$(CSI_ENDPOINT)"

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	driverName    = "csi.quobyte.com"
-	driverVersion = "v1.0.0" // Based on CSI spec version v1.0.0
+	driverVersion = "v1.0.4" // Based on CSI spec version v1.0.0
 )
 
 // QuobyteDriver CSI driver type

--- a/driver/mounter.go
+++ b/driver/mounter.go
@@ -45,7 +45,7 @@ func Unmount(target string) error {
 		return errors.New("Given unmount path is empty")
 	}
 	if out, err := exec.Command(cmd, target).CombinedOutput(); err != nil {
-		return fmt.Errorf("failed unmount: %v cmd: '%s %s' command output: %q", err, cmd, target, string(out))
+		klog.Errorf("failed unmount: %v cmd: '%s %s' command output: %q", err, cmd, target, string(out))
 	}
 	return nil
 }


### PR DESCRIPTION
When unmount fails, K8S not cleaning up the mount points
associated with the pod leading to orphaned pods and
log flooding. This patch fixes the issue by logging the
unmount failure in the driver and returning success to
the K8S (hence K8S cleansup properly).

The unmount failure can happen for two reasons:
1) The quobyte client is killed/terminated before
all the application pods are drained.
2) The Quobyte client is crashed and not
available during the unmount requests.