### PR TITLE
Map K8S namespace to Quobyte Tenant

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,14 +39,14 @@ Quobyte CSI is the implementation of
     ```bash
     git clone https://github.com/quobyte/quobyte-csi.git
     cd quobyte-csi
-    git checkout tags/v1.0.4 # checkout release v1.0.4
+    git checkout tags/v1.0.5 # checkout release v1.0.5
     ```
     Using `SSH`
 
     ```bash
     git clone git@github.com:quobyte/quobyte-csi.git
     cd quobyte-csi
-    git checkout tags/v1.0.4 # checkout release v1.0.4
+    git checkout tags/v1.0.5 # checkout release v1.0.5
     ```
 
 2. Edit [deploy/config.yaml](deploy/config.yaml) and configure `quobyte.apiURL` with your Quobyte cluster API URL.

--- a/deploy/csi-driver-PSP.yaml
+++ b/deploy/csi-driver-PSP.yaml
@@ -53,11 +53,12 @@ spec:
       serviceAccount: quobyte-csi-controller-sa
       containers:
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:v1.0.1
+          image: quay.io/k8scsi/csi-provisioner:v1.6.0
           args:
             - "--provisioner=csi.quobyte.com"
             - "--csi-address=$(ADDRESS)"
             - "--v=3"
+            - "--extra-create-metadata=true"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -78,7 +79,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-resizer
-          image: quay.io/k8scsi/csi-resizer:v0.2.0
+          image: quay.io/k8scsi/csi-resizer:v0.5.0
           args:
             - "--v=3"
             - "--csi-address=$(ADDRESS)"
@@ -90,7 +91,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-attacher
-          image: quay.io/k8scsi/csi-attacher:v1.0.1
+          image: quay.io/k8scsi/csi-attacher:v2.2.0
           args:
             - "--v=3"
             - "--csi-address=$(ADDRESS)"
@@ -102,13 +103,16 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: quobyte-csi-plugin
-          image: quay.io/quobyte/csi:v1.0.4
+          image: quay.io/quobyte/csi:v1.0.5
           imagePullPolicy: "Always"
           args :
             - "--csi_socket=$(CSI_ENDPOINT)"
             - "--quobyte_mount_path=$(QUOBYTE_MOUNT_PATH)"
             - "--node_name=$(KUBE_NODE_NAME)"
             - "--api_url=$(QUOBYTE_API_URL)" # Quobyte API URL
+            # For setups that map K8S namespace to tenant
+            # --use_k8s_namespace_as_tenant=true should be set.
+            - "--use_k8s_namespace_as_tenant=false"
           env:
             - name: NODE_ID
               valueFrom:
@@ -373,7 +377,7 @@ spec:
       hostNetwork: true
       containers:
         - name: csi-node-driver-registrar
-          image: quay.io/k8scsi/csi-node-driver-registrar:v1.0.1
+          image: quay.io/k8scsi/csi-node-driver-registrar:v1.3.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -402,13 +406,14 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: quay.io/quobyte/csi:v1.0.4
+          image: quay.io/quobyte/csi:v1.0.5
           imagePullPolicy: "Always"
           args :
             - "--csi_socket=$(CSI_ENDPOINT)"
             - "--quobyte_mount_path=$(QUOBYTE_MOUNT_PATH)"
             - "--node_name=$(KUBE_NODE_NAME)"
             - "--api_url=$(QUOBYTE_API_URL)" # Quobyte API URL
+            - "--use_k8s_namespace_as_tenant=false"
           env:
             - name: NODE_ID
               valueFrom:

--- a/deploy/csi-driver.yaml
+++ b/deploy/csi-driver.yaml
@@ -27,11 +27,12 @@ spec:
       serviceAccount: quobyte-csi-controller-sa
       containers:
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:v1.3.0
+          image: quay.io/k8scsi/csi-provisioner:v1.6.0
           args:
             - "--provisioner=csi.quobyte.com"
             - "--csi-address=$(ADDRESS)"
             - "--v=3"
+            - "--extra-create-metadata=true"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -53,7 +54,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-resizer
-          image: quay.io/k8scsi/csi-resizer:v0.2.0
+          image: quay.io/k8scsi/csi-resizer:v0.5.0
           args:
             - "--v=3"
             - "--csi-address=$(ADDRESS)"
@@ -65,7 +66,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-attacher
-          image: quay.io/k8scsi/csi-attacher:v1.2.0
+          image: quay.io/k8scsi/csi-attacher:v2.2.0
           args:
             - "--v=3"
             - "--csi-address=$(ADDRESS)"
@@ -77,13 +78,16 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: quobyte-csi-plugin
-          image: quay.io/quobyte/csi:v1.0.4
+          image: quay.io/quobyte/csi:v1.0.5
           imagePullPolicy: "Always"
           args :
             - "--csi_socket=$(CSI_ENDPOINT)"
             - "--quobyte_mount_path=$(QUOBYTE_MOUNT_PATH)"
             - "--node_name=$(KUBE_NODE_NAME)"
             - "--api_url=$(QUOBYTE_API_URL)" # Quobyte API URL
+            # For setups that map K8S namespace to tenant
+            # --use_k8s_namespace_as_tenant=true should be set.
+            - "--use_k8s_namespace_as_tenant=false" 
           env:
             - name: NODE_ID
               valueFrom:
@@ -332,7 +336,7 @@ spec:
       hostNetwork: true
       containers:
         - name: csi-node-driver-registrar
-          image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
+          image: quay.io/k8scsi/csi-node-driver-registrar:v1.3.0
           imagePullPolicy: "IfNotPresent"
           args:
             - "--v=3"
@@ -362,13 +366,14 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: quay.io/quobyte/csi:v1.0.4
+          image: quay.io/quobyte/csi:v1.0.5
           imagePullPolicy: "Always"
           args :
             - "--csi_socket=$(CSI_ENDPOINT)"
             - "--quobyte_mount_path=$(QUOBYTE_MOUNT_PATH)"
             - "--node_name=$(KUBE_NODE_NAME)"
             - "--api_url=$(QUOBYTE_API_URL)" # Quobyte API URL
+            - "--use_k8s_namespace_as_tenant=false" 
           env:
             - name: NODE_ID
               valueFrom:

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -21,18 +21,19 @@ const (
 
 // QuobyteDriver CSI driver type
 type QuobyteDriver struct {
-	name             string
-	version          string
-	endpoint         string
-	clientMountPoint string
-	server           *grpc.Server
-	NodeName         string
-	ApiURL           string
+	name                           string
+	version                        string
+	endpoint                       string
+	clientMountPoint               string
+	server                         *grpc.Server
+	NodeName                       string
+	ApiURL                         string
+	UseK8SNamespaceAsQuobyteTenant bool
 }
 
 // NewQuobyteDriver returns the quobyteDriver object
-func NewQuobyteDriver(endpoint, mount, nodeName, apiURL string) *QuobyteDriver {
-	return &QuobyteDriver{driverName, driverVersion, endpoint, mount, nil, nodeName, apiURL}
+func NewQuobyteDriver(endpoint, mount, nodeName, apiURL string, useNamespaceAsQuobyteTenant bool) *QuobyteDriver {
+	return &QuobyteDriver{driverName, driverVersion, endpoint, mount, nil, nodeName, apiURL, useNamespaceAsQuobyteTenant}
 }
 
 // Run starts the grpc server for the driver

--- a/example/StorageClass.yaml
+++ b/example/StorageClass.yaml
@@ -13,6 +13,8 @@ provisioner: csi.quobyte.com
 # Volume expansion only makes sense if volume is created with a quota.
 allowVolumeExpansion: true
 parameters:
+  # ignored if driver is deployed to use K8S namespace as the Quobyte tenant
+  # i.e; K8S namespace "tenant_x" maps to "tenant_x" in Quobyte storage. 
   quobyteTenant: "My Tenant"
   # secret is used for dynamic volume provisioning.
   # The user credentials provided in this secret must have
@@ -29,5 +31,5 @@ parameters:
   createQuota: "true"
   user: root
   group: root
-  accessMode: "770"
+  accessMode: "777"
 reclaimPolicy: Retain

--- a/main.go
+++ b/main.go
@@ -10,10 +10,11 @@ import (
 )
 
 var (
-	endpoint         = flag.String("csi_socket", "unix:///var/lib/kubelet/plugins/quobyte-csi/csi.sock", "CSI endpoint")
-	clientMountPoint = flag.String("quobyte_mount_path", "/mnt/quobyte/mounts", "Mount point for Quobyte Client")
-	apiURL           = flag.String("api_url", "", "Quobyte API URL")
-	nodeName         = flag.String("node_name", "", "Node name from K8S environment")
+	endpoint             = flag.String("csi_socket", "unix:///var/lib/kubelet/plugins/quobyte-csi/csi.sock", "CSI endpoint")
+	clientMountPoint     = flag.String("quobyte_mount_path", "/mnt/quobyte/mounts", "Mount point for Quobyte Client")
+	apiURL               = flag.String("api_url", "", "Quobyte API URL")
+	nodeName             = flag.String("node_name", "", "Node name from K8S environment")
+	useNameSpaceAsTenant = flag.Bool("use_k8s_namespace_as_tenant", false, "Uses K8S PVC.namespace as Quobyte tenant")
 )
 
 func main() {
@@ -25,7 +26,7 @@ func main() {
 
 	// TODO (venkat): validate API url and node name
 
-	qd := driver.NewQuobyteDriver(*endpoint, *clientMountPoint, *nodeName, *apiURL)
+	qd := driver.NewQuobyteDriver(*endpoint, *clientMountPoint, *nodeName, *apiURL, *useNameSpaceAsTenant)
 	err := qd.Run()
 	if err != nil {
 		klog.Errorf("Failed to start Quobyte CSI grpc server due to eroro: %v.", err)


### PR DESCRIPTION
Driver should be deployed with
--use_k8s_namespace_as_tenant=true. Defaultly
this option is disabled and should be enabled
by user.

Tenant is not created by Quobyte CSI plugin
and must be present in the Quobyte Storgate
before being used.

If mapping is enabled, StorageClass.parameters.
quobyteTenant is ignored and PVC.namespace is
used as quobyteTenant.