### PR TITLE
PSP: Fix indentation for the PSP definitions

### DIFF
--- a/quobyte-csi-driver/templates/csi-driver.yaml
+++ b/quobyte-csi-driver/templates/csi-driver.yaml
@@ -461,84 +461,84 @@ roleRef:
   name: quobyte-csi-driver-registrar-role-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
   apiGroup: rbac.authorization.k8s.io
 
-  {{ if .Values.quobyte.enableSnapshots }}
-  ---
-  kind: ClusterRole
-  apiVersion: rbac.authorization.k8s.io/v1
-  metadata:
-    # rename if there are conflicts
-    name: external-snapshotter-runner-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
-  rules:
-    - apiGroups: [""]
-      resources: ["events"]
-      verbs: ["list", "watch", "create", "update", "patch"]
-    # Secret permission is optional.
-    # Enable it if your driver needs secret.
-    # For example, `csi.storage.k8s.io/snapshotter-secret-name` is set in VolumeSnapshotClass.
-    # See https://kubernetes-csi.github.io/docs/secrets-and-credentials.html for more details.
-    - apiGroups: [""]
-      resources: ["secrets"]
-      verbs: ["get", "list"]
-    - apiGroups: ["snapshot.storage.k8s.io"]
-      resources: ["volumesnapshotclasses"]
-      verbs: ["get", "list", "watch"]
-    - apiGroups: ["snapshot.storage.k8s.io"]
-      resources: ["volumesnapshotcontents"]
-      verbs: ["create", "get", "list", "watch", "update", "delete"]
-    - apiGroups: ["snapshot.storage.k8s.io"]
-      resources: ["volumesnapshotcontents/status"]
-      verbs: ["update"]
-    - apiGroups: ['policy']
-      resources: ['podsecuritypolicies']
-      verbs:     ['use']
-      resourceNames:
-        - quobyte-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
-  
-  ---
-  kind: ClusterRoleBinding
-  apiVersion: rbac.authorization.k8s.io/v1
-  metadata:
-    name: csi-snapshotter-role-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
-  subjects:
-    - kind: ServiceAccount
-      name: quobyte-csi-controller-sa-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
-      namespace: kube-system
-  roleRef:
-    kind: ClusterRole
-    name: external-snapshotter-runner-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
-    apiGroup: rbac.authorization.k8s.io
-  
-  ---
-  kind: Role
-  apiVersion: rbac.authorization.k8s.io/v1
-  metadata:
-    namespace: kube-system
-    name: external-snapshotter-leaderelection-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
-  rules:
-  - apiGroups: ["coordination.k8s.io"]
-    resources: ["leases"]
-    verbs: ["get", "watch", "list", "delete", "update", "create"]
+{{ if .Values.quobyte.enableSnapshots }}
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  # rename if there are conflicts
+  name: external-snapshotter-runner-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
+rules:
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  # Secret permission is optional.
+  # Enable it if your driver needs secret.
+  # For example, `csi.storage.k8s.io/snapshotter-secret-name` is set in VolumeSnapshotClass.
+  # See https://kubernetes-csi.github.io/docs/secrets-and-credentials.html for more details.
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["create", "get", "list", "watch", "update", "delete"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents/status"]
+    verbs: ["update"]
   - apiGroups: ['policy']
     resources: ['podsecuritypolicies']
     verbs:     ['use']
     resourceNames:
       - quobyte-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
-  
-  ---
-  kind: RoleBinding
-  apiVersion: rbac.authorization.k8s.io/v1
-  metadata:
-    name: external-snapshotter-leaderelection-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-snapshotter-role-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
+subjects:
+  - kind: ServiceAccount
+    name: quobyte-csi-controller-sa-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
     namespace: kube-system
-  subjects:
-    - kind: ServiceAccount
-      name: quobyte-csi-controller-sa-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
-      namespace: kube-system
-  roleRef:
-    kind: Role
-    name: external-snapshotter-leaderelection-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
-    apiGroup: rbac.authorization.k8s.io
-  {{ end }}
+roleRef:
+  kind: ClusterRole
+  name: external-snapshotter-runner-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
+  apiGroup: rbac.authorization.k8s.io
+
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: kube-system
+  name: external-snapshotter-leaderelection-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
+rules:
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["get", "watch", "list", "delete", "update", "create"]
+- apiGroups: ['policy']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+    - quobyte-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: external-snapshotter-leaderelection-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
+  namespace: kube-system
+subjects:
+  - kind: ServiceAccount
+    name: quobyte-csi-controller-sa-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
+    namespace: kube-system
+roleRef:
+  kind: Role
+  name: external-snapshotter-leaderelection-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
+  apiGroup: rbac.authorization.k8s.io
+{{ end }}
 
 {{ else }} # Without pod security policies
 apiVersion: storage.k8s.io/v1beta1


### PR DESCRIPTION
The yaml has indentation issue for the combination
enableSnapshots: true and podSecurityPolicies: true

https://github.com/quobyte/quobyte-csi/issues/22