### PR TITLE
Fix mounting issue on k8s v1.20.x

### DIFF
--- a/example/volume-snapshot-class.yaml
+++ b/example/volume-snapshot-class.yaml
@@ -1,4 +1,4 @@
-apiVersion: snapshot.storage.k8s.io/v1beta1
+apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshotClass
 metadata:
   name: quobyte-csi-snapshotclass

--- a/example/volume-snapshot-content-pre-provisioned.yaml
+++ b/example/volume-snapshot-content-pre-provisioned.yaml
@@ -1,7 +1,7 @@
 # This must be created for the pre-provisioned volume snapshot content
 # based on https://kubernetes.io/docs/concepts/storage/volume-snapshots/#volume-snapshot-contents
 
-apiVersion: snapshot.storage.k8s.io/v1beta1
+apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshotContent
 metadata:
   name: snapcontent-pre-provisioned

--- a/example/volume-snapshot-dynamic-provision.yaml
+++ b/example/volume-snapshot-dynamic-provision.yaml
@@ -1,4 +1,4 @@
-apiVersion: snapshot.storage.k8s.io/v1beta1
+apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshot
 metadata:
   name: test-snapshot-dynamic-provision

--- a/example/volume-snapshot-pre-provisioned.yaml
+++ b/example/volume-snapshot-pre-provisioned.yaml
@@ -1,4 +1,4 @@
-apiVersion: snapshot.storage.k8s.io/v1beta1
+apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshot
 metadata:
   # Should match VolumeSnapshotContent.spec.volumeSnapshotRef.name

--- a/quobyte-csi-driver/templates/csi-driver.yaml
+++ b/quobyte-csi-driver/templates/csi-driver.yaml
@@ -147,9 +147,19 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
+            {{ if .Values.quobyte.mapHostCertsIntoContainer }}
+            - name: certs
+              mountPath: /etc/ssl/certs/
+            {{ end }}
       volumes:
         - name: socket-dir
           emptyDir: {}
+        {{ if .Values.quobyte.mapHostCertsIntoContainer }}
+        - name: certs
+          hostPath:
+            path: /etc/ssl/certs/
+            type: Directory
+        {{ end }}
 ---
 
 kind: ServiceAccount
@@ -402,6 +412,10 @@ spec:
               mountPropagation: "Bidirectional"
             - name: plugin-dir
               mountPath: /csi
+            {{ if .Values.quobyte.mapHostCertsIntoContainer }}
+            - name: certs
+              mountPath: /etc/ssl/certs/
+            {{ end }}
         {{ if .Values.quobyte.podKiller.enable }}
         - name: quobyte-pod-killer
           securityContext:
@@ -445,6 +459,12 @@ spec:
           hostPath:
             path: /var/lib/kubelet/plugins_registry/
             type: DirectoryOrCreate
+        {{ if .Values.quobyte.mapHostCertsIntoContainer }}
+        - name: certs
+          hostPath:
+            path: /etc/ssl/certs/
+            type: Directory
+        {{ end }}
 ---
 
 apiVersion: v1
@@ -701,6 +721,10 @@ spec:
               mountPath: /var/lib/csi/sockets/pluginproxy/
             - name: log-dir
               mountPath: /tmp
+            {{ if .Values.quobyte.mapHostCertsIntoContainer }}
+            - name: certs
+              mountPath: /etc/ssl/certs/
+            {{ end }}
       volumes:
         - name: socket-dir
           emptyDir: {}
@@ -708,6 +732,12 @@ spec:
           hostPath:
             path: /tmp
             type: Directory
+        {{ if .Values.quobyte.mapHostCertsIntoContainer }}
+        - name: certs
+          hostPath:
+            path: /etc/ssl/certs/
+            type: Directory
+        {{ end }}
 ---
 
 kind: ServiceAccount
@@ -1014,6 +1044,10 @@ spec:
               mountPath: /csi
             - name: log-dir
               mountPath: /tmp
+            {{ if .Values.quobyte.mapHostCertsIntoContainer }}
+            - name: certs
+              mountPath: /etc/ssl/certs/
+            {{ end }}
        {{ if .Values.quobyte.podKiller.enable }}
         - name: quobyte-pod-killer
           securityContext:
@@ -1061,6 +1095,12 @@ spec:
           hostPath:
             path: /tmp
             type: Directory
+        {{ if .Values.quobyte.mapHostCertsIntoContainer }}
+        - name: certs
+          hostPath:
+            path: /etc/ssl/certs/
+            type: Directory
+        {{ end }}
 ---
 
 apiVersion: v1

--- a/quobyte-csi-driver/values.yaml
+++ b/quobyte-csi-driver/values.yaml
@@ -33,9 +33,11 @@ quobyte:
   # enabled with access keys. To enable access keys on native client,
   # add "enable-access-contexts" in /etc/quobyte/client-service.cfg.
   # For container based client configuration, see client.yaml definition.
+  # Requires Quobyte 3.x to enable access keys
   enableAccessKeys: false
   
-  # Enabling this feature requires additional driver setup (see README.md) 
+  # Enabling this feature requires additional driver setup (see README.md)
+  # Quobyte 3.x is recommended for snapshots
   enableSnapshots: false
   
   # Set to true to deploy csi driver with pod security policies.
@@ -53,10 +55,10 @@ quobyte:
   # Please do NOT change the dev: configuration unless otherwise adviced to change.
   dev:
     # CSI Release version
-    csiProvisionerVersion: "v1.4.1"
+    csiProvisionerVersion: "v1.5.0"
     # Release container
     # github.com/quobyte/quobyte-csi
-    csiImage: "quay.io/quobyte/csi:v1.4.1"
+    csiImage: "quay.io/quobyte/csi:v1.5.0"
     # github.com/quobyte/pod-killer
     podKillerImage: quay.io/quobyte/pod-killer:v0.1.0
     # k8s sidecar containers (https://github.com/kubernetes-csi/)

--- a/quobyte-csi-driver/values.yaml
+++ b/quobyte-csi-driver/values.yaml
@@ -1,7 +1,14 @@
 quobyte:
   # apiURL should be of the form http(s)://<ip or resolvable host>:<port>
   # Example Quobyte API: http://hydrogen.quobyte.com:26801
-  apiURL: "http://10.125.2.77:10330" 
+  apiURL: "http://10.125.2.77:10330"
+  
+  # Maps /etc/ssl/certs/ from host into Quobyte CSI containers.
+  # Must set to true, if you have https:// API URL. Otherwise,
+  # can be set to false.
+  # If you are using private CA certificate, add the CA to
+  # all k8s hosts before deploying driver.
+  mapHostCertsIntoContainer: true
   
   # Quobyte client should be deployed with <clientMountPoint>/mounts
   # For example, if you set clientMountPoint: /mnt/quobyte then quobyte


### PR DESCRIPTION
Fixes a mounting issue on k8s v1.20.x

Kubenetes no longer [creating whole path](https://github.com/quobyte/quobyte-csi/issues/28) inside /var/lib/pods/... (leaving off last two directories)

