### PR TITLE
Fix missing selector for PSP

### DIFF
--- a/quobyte-csi-driver/templates/csi-driver.yaml
+++ b/quobyte-csi-driver/templates/csi-driver.yaml
@@ -39,6 +39,9 @@ metadata:
   name: quobyte-csi-controller-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
   namespace: kube-system
 spec:
+  selector:
+    matchLabels:
+      app: quobyte-csi-controller-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
   serviceName: quobyte-csi-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
   replicas: 1
   template:


### PR DESCRIPTION
This commit will fix missing selector for PSP.

Currently StatefulSet `quobyte-csi-controller-csi-quobyte-com` for PSP does not have required `selector` field, so we cannot apply PSP-enabled `quobyte-csi` without change.

```
$ helm template --set quobyte.podSecurityPolicies=true quobyte-csi-driver/ | kubectl apply -f - --dry-run=client
# ...
error: error validating "STDIN": error validating data: ValidationError(StatefulSet.spec): missing required field "selector" in io.k8s.api.apps.v1.StatefulSetSpec; if you choose to ignore these errors, turn validation off with --validate=false
```

I verified this PR fixed the issue as follows.

```
$ helm template --set quobyte.podSecurityPolicies=true quobyte-csi-driver/ | kubectl apply -f - --dry-run=client
# There is no validation error
```
