### PR TITLE
Remove unused namespace for ClusterRole

### DIFF
--- a/quobyte-csi-driver/templates/csi-driver.yaml
+++ b/quobyte-csi-driver/templates/csi-driver.yaml
@@ -479,7 +479,6 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: quobyte-csi-driver-registrar-role-{{ .Values.quobyte.csiProvisionerName | replace "." "-" }}
-  namespace: kube-system
 rules:
   - apiGroups: [""]
     resources: ["events"]


### PR DESCRIPTION
This commit will remove unused namespace for ClusterRole which is cluster-scoped.