### PR TITLE
Remove duplicate imagePullPolicy for quobyte-csi-plugin

### DIFF
--- a/quobyte-csi-driver/templates/csi-driver.yaml
+++ b/quobyte-csi-driver/templates/csi-driver.yaml
@@ -118,7 +118,6 @@ spec:
       {{ end }}
         - name: quobyte-csi-plugin
           image: {{ .Values.quobyte.dev.csiImage }}
-          imagePullPolicy: "Always"
           args :
             - "--csi_socket=$(CSI_ENDPOINT)"
             - "--quobyte_mount_path=$(QUOBYTE_MOUNT_PATH)"
@@ -690,7 +689,6 @@ spec:
        {{ end }}
         - name: quobyte-csi-plugin
           image: {{ .Values.quobyte.dev.csiImage }}
-          imagePullPolicy: "Always"
           args :
             - "--csi_socket=$(CSI_ENDPOINT)"
             - "--quobyte_mount_path=$(QUOBYTE_MOUNT_PATH)"


### PR DESCRIPTION
This commit will remove duplicate `imagePullPolicy` keys. Duplicate keys cause `unmarshal errors` in latest kustomize ( https://github.com/kubernetes-sigs/kustomize/issues/3480)

```
$ kustomize build base
2021/02/16 15:08:49 failed to decode ynode: yaml: unmarshal errors:
  line 115: mapping key "imagePullPolicy" already defined at line 90
```