### PR TITLE
Add GET_VOLUME_STATS capability to NodeGetCapabilities

### DIFF
--- a/driver/node.go
+++ b/driver/node.go
@@ -166,7 +166,7 @@ func (d *QuobyteDriver) NodeGetCapabilities(ctx context.Context, req *csi.NodeGe
 			{
 				Type: &csi.NodeServiceCapability_Rpc{
 					Rpc: &csi.NodeServiceCapability_RPC{
-						Type: csi.NodeServiceCapability_RPC_UNKNOWN,
+						Type: csi.NodeServiceCapability_RPC_GET_VOLUME_STATS,
 					},
 				},
 			},


### PR DESCRIPTION
Fixes: https://github.com/quobyte/quobyte-csi/issues/34
This commit enables the VolumeStats feature in Kubernetes.