### PR TITLE
Add --csi-address flag for csi-snapshotter

### DIFF
--- a/quobyte-csi-driver/templates/pods/containers/_sidecar_snapshotter_container.tpl
+++ b/quobyte-csi-driver/templates/pods/containers/_sidecar_snapshotter_container.tpl
@@ -11,4 +11,11 @@
   args:
     - "--v=3"
     - "--leader-election=false"
+    - "--csi-address=$(ADDRESS)"
+  env:
+    - name: ADDRESS
+      value: /var/lib/csi/sockets/pluginproxy/csi.sock
+  volumeMounts:
+    - name: socket-dir
+      mountPath: /var/lib/csi/sockets/pluginproxy/
 {{- end }}

--- a/quobyte-csi-driver/tests/__snapshot__/csi_driver_test.yaml.snap
+++ b/quobyte-csi-driver/tests/__snapshot__/csi_driver_test.yaml.snap
@@ -348,6 +348,10 @@ should render when resource limits are provided:
           - args:
             - --v=3
             - --leader-election=false
+            - --csi-address=$(ADDRESS)
+            env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
             image: quay.io/k8scsi/csi-snapshotter:v3.0.3
             imagePullPolicy: IfNotPresent
             name: csi-snapshotter
@@ -355,6 +359,9 @@ should render when resource limits are provided:
               limits:
                 cpu: 50m
                 memory: 50Mi
+            volumeMounts:
+            - mountPath: /var/lib/csi/sockets/pluginproxy/
+              name: socket-dir
           - args:
             - --csi_socket=$(CSI_ENDPOINT)
             - --quobyte_mount_path=$(QUOBYTE_MOUNT_PATH)


### PR DESCRIPTION
This commit adds missing --csi-address flag for csi-snapshotter.

I found that csi-snapshotter cannot connect the CSI endpoint when enabling snapshots in helm value. (`enableSnapshots: true`)
```
W0119 06:23:43.531490       1 connection.go:172] Still connecting to unix:///run/csi/socket
W0119 06:23:53.531478       1 connection.go:172] Still connecting to unix:///run/csi/socket
```

`unix:///run/csi/socket` is the default value for csi endpoint, but quobyte-csi specifies `unix:///var/lib/csi/sockets/pluginproxy/csi.sock` for the endpoint.
https://github.com/quobyte/quobyte-csi/blob/v1.8.0/quobyte-csi-driver/templates/pods/containers/_quboyte_csi_controller_container.tpl#L27-L28

Other sidecars specify the path correctly like [this](https://github.com/quobyte/quobyte-csi/blob/v1.8.0/quobyte-csi-driver/templates/pods/containers/_sidecar_attacher_container.tpl#L13-L19).
