### PR TITLE
1.8.1 release

### DIFF
--- a/driver/controller.go
+++ b/driver/controller.go
@@ -295,7 +295,7 @@ func (d *QuobyteDriver) CreateSnapshot(ctx context.Context, req *csi.CreateSnaps
 	if pinned, ok := req.Parameters[pinnedKey]; ok {
 		pinnedVal, err := strconv.ParseBool(pinned)
 		if err != nil {
-			return nil, fmt.Errorf("VolumeSnapshotClass.Parameters.pinned must be ture/false. Configured value %s is invalid.", pinned)
+			return nil, fmt.Errorf("VolumeSnapshotClass.Parameters.pinned must be true/false. Configured value %s is invalid.", pinned)
 		}
 		isPinned = pinnedVal
 	} else {

--- a/driver/controller.go
+++ b/driver/controller.go
@@ -201,7 +201,7 @@ func (d *QuobyteDriver) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeR
 
 	secrets := req.GetSecrets()
 	if len(secrets) == 0 {
-		return nil, fmt.Errorf("secrets are required delete volume." +
+		return nil, fmt.Errorf("secrets are required to delete a volume." +
 			" Provide csi.storage.k8s.io/provisioner-secret-name/namespace in storage class")
 	}
 	params := strings.Split(volID, SEPARATOR)
@@ -216,7 +216,7 @@ func (d *QuobyteDriver) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeR
 	if d.QuobyteVersion == 2 {
 		err = quobyteClient.EraseVolumeByResolvingNamesToUUID_2X(params[1], params[0])
 	} else {
-		err= quobyteClient.EraseVolumeByResolvingNamesToUUID(params[1], params[0], d.ImmediateErase)
+		err = quobyteClient.EraseVolumeByResolvingNamesToUUID(params[1], params[0], d.ImmediateErase)
 	}
 
 	if err != nil {

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -59,7 +59,7 @@ func NewQuobyteDriver(
 // Run starts the grpc server for the driver
 func (qd *QuobyteDriver) Run() error {
 	if len(qd.clientMountPoint) == 0 {
-		return fmt.Errorf("--quobyte_mount_path is required. Supplied value should match environment varialbe QUOBYTE_MOUNT_POINT of Quobyte client pod.")
+		return fmt.Errorf("--quobyte_mount_path is required. Supplied value should match environment variable QUOBYTE_MOUNT_POINT of Quobyte client pod.")
 	}
 	if len(qd.Name) == 0 {
 		return fmt.Errorf("--driver_name should not be empty")

--- a/driver/node.go
+++ b/driver/node.go
@@ -64,8 +64,9 @@ func (d *QuobyteDriver) NodePublishVolume(ctx context.Context, req *csi.NodePubl
 	}
 
 	var volUUID string
-	if len(secrets) == 0 {
-		klog.Infof("csiNodePublishSecret is  not received. Assuming volume given with UUID")
+	if len(secrets) == 0 || !hasApiCredentials(secrets) {
+		// cannot resolve volume Id without Quobyte API credentials if tenant name & volume name is given..assume volume uuid
+		klog.Infof("csiNodePublishSecret is  not received with sufficient Quobyte API credential. Assuming volume given with UUID")
 		volUUID = volParts[1]
 	} else {
 		quobyteClient, err := getAPIClient(secrets, d.ApiURL)

--- a/driver/node.go
+++ b/driver/node.go
@@ -65,7 +65,7 @@ func (d *QuobyteDriver) NodePublishVolume(ctx context.Context, req *csi.NodePubl
 
 	var volUUID string
 	if len(secrets) == 0 {
-		klog.Infof("csiNodePublishSecret is  not recieved. Assuming volume given with UUID")
+		klog.Infof("csiNodePublishSecret is  not received. Assuming volume given with UUID")
 		volUUID = volParts[1]
 	} else {
 		quobyteClient, err := getAPIClient(secrets, d.ApiURL)
@@ -205,11 +205,11 @@ func (d *QuobyteDriver) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGet
 	}
 
 	usedBytes := (int64(statfs.Blocks) - int64(statfs.Bfree)) * int64(statfs.Bsize)
-	availbleBytes := int64(statfs.Bavail) * int64(statfs.Bsize)
+	availableBytes := int64(statfs.Bavail) * int64(statfs.Bsize)
 	totalBytes := int64(statfs.Blocks) * int64(statfs.Bsize)
 
 	usedInodes := int64(statfs.Files) - int64(statfs.Ffree)
-	availbleInodes := int64(statfs.Ffree)
+	availableInodes := int64(statfs.Ffree)
 	totalInodes := int64(statfs.Files)
 
 	resp := &csi.NodeGetVolumeStatsResponse{
@@ -217,13 +217,13 @@ func (d *QuobyteDriver) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGet
 			{
 				Unit:      csi.VolumeUsage_BYTES,
 				Used:      usedBytes,
-				Available: availbleBytes,
+				Available: availableBytes,
 				Total:     totalBytes,
 			},
 			{
 				Unit:      csi.VolumeUsage_INODES,
 				Used:      usedInodes,
-				Available: availbleInodes,
+				Available: availableInodes,
 				Total:     totalInodes,
 			},
 		},

--- a/driver/utils.go
+++ b/driver/utils.go
@@ -139,10 +139,10 @@ func getSanitizedPodUUIDFromPath(podVolPath string) string {
 func parseLabels(labels string) ([]*quobyte.Label, error) {
 	labelKVs := strings.Split(labels, ",")
 	parsedLabels := make([]*quobyte.Label, 0)
-	for _, lableKV := range labelKVs {
-		labelKVArr := strings.Split(lableKV, ":")
+	for _, labelKV := range labelKVs {
+		labelKVArr := strings.Split(labelKV, ":")
 		if len(labelKVArr) < 2 {
-			return parsedLabels, fmt.Errorf("Found invalid label '%s'. Label should be <Name>:<Value>", lableKV)
+			return parsedLabels, fmt.Errorf("Found invalid label '%s'. Label should be <Name>:<Value>", labelKV)
 		}
 		label := &quobyte.Label{
 			Name:  labelKVArr[0],

--- a/driver/utils.go
+++ b/driver/utils.go
@@ -2,10 +2,11 @@ package driver
 
 import (
 	"fmt"
-	"k8s.io/klog"
 	"net/url"
 	"os/exec"
 	"strings"
+
+	"k8s.io/klog"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	cache "github.com/hashicorp/golang-lru"
@@ -17,6 +18,11 @@ var (
 	VOL_UUID_LOCATOR = "used by volume "
 	POD_UUID_LOCATOR = "/pods/"
 	POD_VOL_LOCATOR  = "/volume"
+)
+
+const (
+	secretUserKey     string = "user"
+	secretPasswordKey string = "password"
 )
 
 var clientCache *cache.Cache = nil
@@ -38,11 +44,11 @@ func getAPIClient(secrets map[string]string, apiURL *url.URL) (*quobyte.QuobyteC
 	var apiUser, apiPass string
 	var ok bool
 
-	if apiUser, ok = secrets["user"]; !ok {
+	if apiUser, ok = secrets[secretUserKey]; !ok {
 		return nil, fmt.Errorf("Quobyte API user missing in secret")
 	}
 
-	if apiPass, ok = secrets["password"]; !ok {
+	if apiPass, ok = secrets[secretPasswordKey]; !ok {
 		return nil, fmt.Errorf("Quobyte API password missing in secret")
 	}
 
@@ -81,6 +87,7 @@ func setfattr(key, val, mountPath string) error {
 	}
 	return nil
 }
+
 func (d *QuobyteDriver) expandVolume(req *ExpandVolumeReq) error {
 	volID := req.volID
 	volParts := strings.Split(volID, "|")
@@ -155,4 +162,10 @@ func parseLabels(labels string) ([]*quobyte.Label, error) {
 
 func getInvlaidSnapshotIdError(snapshotId string) error {
 	return fmt.Errorf("given snapshot id %s is not of the form <Tenant>%s<Volume>%s<Snapshot_Name>", snapshotId, SEPARATOR, SEPARATOR)
+}
+
+func hasApiCredentials(secrets map[string]string) bool {
+	_, hasQuobyteApiUser := secrets[secretUserKey]
+	_, hasQuobyteApiPassword := secrets[secretPasswordKey]
+	return hasQuobyteApiUser && hasQuobyteApiPassword
 }

--- a/example/StorageClass.yaml
+++ b/example/StorageClass.yaml
@@ -25,7 +25,7 @@ parameters:
   # volume create/delete permissions for `quobyteTenant` above.
   csi.storage.k8s.io/provisioner-secret-name: "quobyte-admin-secret"
   csi.storage.k8s.io/provisioner-secret-namespace: "quobyte"
-  # Resize volume requires secrets to commuicate with Quobyte API
+  # Resize volume requires secrets to communicate with Quobyte API
   csi.storage.k8s.io/controller-expand-secret-name: "quobyte-admin-secret"
   csi.storage.k8s.io/controller-expand-secret-namespace: "quobyte"
   # Mount secrets

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/container-storage-interface/spec v1.3.0
 	github.com/golang/protobuf v1.3.1
 	github.com/hashicorp/golang-lru v0.5.4
-	github.com/quobyte/api v1.2.1
+	github.com/quobyte/api v1.2.2
 	golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a
 	golang.org/x/text v0.3.2 // indirect
 	google.golang.org/grpc v1.21.0

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,8 @@ github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
-github.com/quobyte/api v1.2.1 h1:DwP+altrMA8/nZqGTYfGiZGN4TyHnKvqCnVWg4wqZJU=
-github.com/quobyte/api v1.2.1/go.mod h1:1g8U92wHQfxyKWPmqFNx7puGp+7TTDn8XoSo3Nw8qCA=
+github.com/quobyte/api v1.2.2 h1:mMiyiNVr094lvgfKpuGNz3PPablhNhDRhxYggmLhaHo=
+github.com/quobyte/api v1.2.2/go.mod h1:1g8U92wHQfxyKWPmqFNx7puGp+7TTDn8XoSo3Nw8qCA=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a h1:oWX7TPOiFAMXLq8o0ikBYfCJVlRHBcsciT5bXOrH628=


### PR DESCRIPTION
* Quobyte API upgrade to v1.2.2
* Make Quobyte api credentials optional in node publish secrets
   * Pre-provisioned volume PV should be configured with volume UUID to have optional api credentials