### PR TITLE
Remove unnecessary namespace

### DIFF
--- a/csi-driver-templates/templates/pods/rbac/_sidecar_node_registrar_rbac.tpl
+++ b/csi-driver-templates/templates/pods/rbac/_sidecar_node_registrar_rbac.tpl
@@ -4,7 +4,6 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: quobyte-csi-driver-registrar-role-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
-  namespace: kube-system
 rules:
   - apiGroups: [""]
     resources: ["events"]


### PR DESCRIPTION
This commit removes unnecessary namespace in ClusterRole(non-namespaced).

FYI: I didn't update template snapshot because I got some diffs other than this change.

```
% helm unittest -u ./csi-driver-templates     

### Chart [ quobyte-csi-driver ] ./csi-driver-templates

 PASS  test csi driver  csi-driver-templates/tests/csi_driver_test.yaml

Charts:      1 passed, 1 total
Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
Snapshot:    41 passed, 41 total
Time:        21.536791ms

% git diff
...
     kind: ClusterRole
     metadata:
       name: quobyte-csi-driver-registrar-role-csi-quobyte-com
-      namespace: kube-system
     rules:
...
               name: kubelet-dir
-            - mountPath: /home/quobyte
-              mountPropagation: Bidirectional
+            - hostPath:
+                path: /home/quobyte
+                type: DirectoryOrCreate
               name: quobyte-mounts
-            - mountPath: /csi
+            - hostPath:
+                path: /var/lib/kubelet/plugins/csi.quobyte.com
+                type: DirectoryOrCreate
               name: plugin-dir
-            - mountPath: /tmp
+            - hostPath:
+                path: /var/lib/kubelet/plugins_registry/
+                type: DirectoryOrCreate
+              name: registration-dir
+            - hostPath:
+                path: /tmp
+                type: Directory
               name: log-dir
-            - mountPath: /etc/ssl/certs/
+            - hostPath:
+                path: /etc/ssl/certs/
+                type: Directory
               name: certs
...
```