### PR TITLE
Dedup pod killer svc and separate nodeSelectors

### DIFF
--- a/csi-driver-templates/templates/pods/_quobyte_csi_controller_pod.tpl
+++ b/csi-driver-templates/templates/pods/_quobyte_csi_controller_pod.tpl
@@ -26,9 +26,9 @@ spec:
         app: quobyte-csi-controller-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
         role: quobyte-csi-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
     spec:
-    {{- if default "" .Values.quobyte.csiDriverNodeSelector | trim }}
+    {{- if .Values.quobyte.csiControllerNodeSelector }}
       nodeSelector:
-        {{ .Values.quobyte.csiDriverNodeSelector | trim }}
+        {{- .Values.quobyte.csiControllerNodeSelector | toYaml | nindent 8 }}
     {{- end }}
       priorityClassName: system-cluster-critical
       serviceAccount: quobyte-csi-controller-sa-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}

--- a/csi-driver-templates/templates/pods/_quobyte_csi_node_driver_pod.tpl
+++ b/csi-driver-templates/templates/pods/_quobyte_csi_node_driver_pod.tpl
@@ -19,9 +19,9 @@ spec:
         app: quobyte-csi-node-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
         role: quobyte-csi
     spec:
-    {{- if default "" .Values.quobyte.csiDriverNodeSelector | trim }}
+    {{- if .Values.quobyte.csiDriverNodeSelector }}
       nodeSelector:
-        {{ .Values.quobyte.csiDriverNodeSelector | trim }}
+        {{- .Values.quobyte.csiDriverNodeSelector | toYaml | nindent 8 }}
     {{- end }}
       priorityClassName: system-node-critical
       serviceAccount: quobyte-csi-node-sa-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}

--- a/csi-driver-templates/templates/pods/_quobyte_csi_pod_killer_cache.tpl
+++ b/csi-driver-templates/templates/pods/_quobyte_csi_pod_killer_cache.tpl
@@ -21,9 +21,9 @@ spec:
         app: quobyte-csi-pod-killer-cache-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
         role: quobyte-csi-pod-killer-cache-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
     spec:
-    {{- if default "" .Values.quobyte.podKillerCacheNodeSelector | trim }}
+    {{- if .Values.quobyte.podKiller.nodeSelector }}
       nodeSelector:
-        {{ .Values.quobyte.podKillerCacheNodeSelector | trim }}
+        {{- .Values.quobyte.podKiller.nodeSelector | toYaml | nindent 8 }}
     {{- end }}
       priorityClassName: system-cluster-critical
       serviceAccount: quobyte-csi-pod-killer-cache-sa-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
@@ -37,7 +37,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: quobyte-pod-killer-cache
+  name: quobyte-pod-killer-cache-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
   namespace: kube-system
 spec:
   selector:

--- a/csi-driver-templates/templates/pods/containers/_quobyte_pod_mount_monitor_container.tpl
+++ b/csi-driver-templates/templates/pods/containers/_quobyte_pod_mount_monitor_container.tpl
@@ -14,7 +14,7 @@
   args:
     - "--node_name=$(KUBE_NODE_NAME)"
     - "--driver_name={{ .Values.quobyte.csiProvisionerName }}"
-    - "--service_url=http://quobyte-pod-killer-cache.$(NAMESPACE).svc.cluster.local:80/"
+    - "--service_url=http://quobyte-pod-killer-cache-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}.$(NAMESPACE).svc.cluster.local:80/"
     - "--monitoring_interval={{ .Values.quobyte.podKiller.monitoringInterval }}"
     - "--role=monitor"
   env:

--- a/csi-driver-templates/values.yaml
+++ b/csi-driver-templates/values.yaml
@@ -75,11 +75,12 @@ quobyte:
   # Empty means all the nodes in the k8s cluster i.e. no node selector will be used.
   # nodeSelector: "<node-label-name>: '<node-label-value>'"
   # Example: csiDriverNodeSelector: "quobyteCsiDriverNode: 'true'"
-  csiDriverNodeSelector: ""
-  # Pod killer cache node selector - leaving it empty creates pod killer cache pod
+  csiDriverNodeSelector: {}
+  # CSI controller node selector - leaving it empty creates CSI controller pod
   # on any of the k8s node
-  # Example: podKillerCacheNodeSelector: "quobytePodCacheNode: 'true'"
-  podKillerCacheNodeSelector: ""
+  # nodeSelector object of form: <node-label-name>: '<node-label-value>'
+  csiControllerNodeSelector: {}
+
   podKiller:
     # To disable pod killer, uninstall current CSI driver (helm uninstall <chart-name>)
     # set enable: false and install CSI driver again
@@ -94,6 +95,7 @@ quobyte:
     # pod killer pod so that the cache endpoint is resolved.
     # See https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
     dnsPolicy: ""
+    nodeSelector: {}
 
   # The dev configuration is intended for Quobyte Developers and internal use.
   # Please do NOT change the dev: configuration unless otherwise advised to change.


### PR DESCRIPTION
### Node Selectors

Node selector terms are an object not a string. 
I've also added separate nodeSelector terms for each component.
In our setup podKiller and csiController can run on any node, however the nodeDriver daemonset should only run on nodes with a specific label. 

### Pod Killer Cache svc
In our environment we have multiple quobyte clusters and therefore need to deploy this chart multiple times. As a result all manifests must be uniquely named. pkc was creating a service with the same name for each deplyment